### PR TITLE
remove sql-load

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,11 @@ var query = require('pg-query');
 
 query.connectionParameters = process.env.DATABASE_URL;
 
-var get = require('sql-load')('sql/get');
-var del = require('sql-load')('sql/delete');
-var update = require('sql-load')('sql/update');
+var readfile = require('fs').readFileSync;
+
+var get = readfile(__dirname + '/sql/get.sql', 'utf8');
+var del = readfile(__dirname + '/sql/delete.sql', 'utf8');
+var update = readfile(__dirname + '/sql/update.sql', 'utf8');
 
 module.exports = {
   get: function(callback){

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   },
   "dependencies": {
     "pg": "^4.4.2",
-    "pg-query": "^0.11.0",
-    "sql-load": "0.0.2"
+    "pg-query": "^0.11.0"
   },
   "devDependencies": {
     "@phated/eslint-config-iceddev": "^0.2.1",


### PR DESCRIPTION
#### What's this PR do?

Replaces sql-load with fs.readFileSync to avoid conflict.
#### What are the important parts of the code?

index.js now uses fs.
#### How should this be tested by the reviewer?

Install in a migrations repo and make sure migrations work.
